### PR TITLE
length 1 vector test for 'ALL' conditions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: edgar
 Type: Package
 Title: Tool for the U.S. SEC EDGAR Retrieval and Parsing of Corporate Filings
-Version: 2.0.3
-Date: 2020-05-20
+Version: 2.0.4
+Date: 2021-06-05
 Author: Gunratan Lonare <lonare.gunratan@gmail.com>, Bharat Patil
     <bharatspatil@gmail.com>
 Maintainer: Gunratan Lonare <lonare.gunratan@gmail.com>

--- a/R/getFilingInfo.R
+++ b/R/getFilingInfo.R
@@ -65,7 +65,7 @@ getFilingInfo <- function(firm.identifier, filing.year, quarter = c(1, 2, 3, 4),
       
       load(filepath)  # Import master Index
       
-      if(form.type == "ALL"){
+      if((length(form.type) == 1) && (form.type == "ALL")){
         form.type <- unique(year.master$form.type)
       }
       

--- a/R/getFilings.R
+++ b/R/getFilings.R
@@ -115,11 +115,11 @@ getFilings <- function(cik.no = "ALL", form.type = "ALL", filing.year, quarter =
     
     load(filepath)  # Import master Index
     
-    if(form.type == "ALL"){
+    if((length(form.type) == 1) && (form.type == "ALL")){
       form.type <- unique(year.master$form.type)
     }
     
-    if( cik.no == "ALL" ){
+    if(length(cik.no) == 1) && (cik.no == "ALL" )){
       year.master <- year.master[which(year.master$form.type %in% form.type 
                                        & year.master$quarter %in% quarter), ]
     } else {


### PR DESCRIPTION
There are a tiny number of places where a parameter is tested to see if it equals `ALL`.

If one is running R with the following safety environment variables set:

- `_R_CHECK_LENGTH_1_CONDITION_=TRUE`
- `_R_CHECK_LENGTH_1_LOGIC2_=TRUE`

they cause the functions with those test to fail. While it's easy to unset them, it is also straightforward to add a check, which is what this PR does.